### PR TITLE
[Feat] 검수 완료된 상품 목록 조회

### DIFF
--- a/src/main/java/com/earth/ureverse/global/mapper/ProductMapper.java
+++ b/src/main/java/com/earth/ureverse/global/mapper/ProductMapper.java
@@ -1,6 +1,7 @@
 package com.earth.ureverse.global.mapper;
 
 import com.earth.ureverse.admin.dto.response.FinishProductResponse;
+import com.earth.ureverse.inspector.dto.response.InspectionCompletedProductDto;
 import com.earth.ureverse.inspector.dto.response.PendingInspectionProductDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -13,4 +14,6 @@ public interface ProductMapper {
     List<PendingInspectionProductDto> getPendingInspectionProductsByInspector(@Param("inspectorId") Long inspectorId);
 
     List<FinishProductResponse> getFinishProducts();
+
+    List<InspectionCompletedProductDto> getInspectionCompletedProductsByInspector(@Param("inspectorId") Long inspectorId);
 }

--- a/src/main/java/com/earth/ureverse/inspector/controller/InspectorController.java
+++ b/src/main/java/com/earth/ureverse/inspector/controller/InspectorController.java
@@ -2,6 +2,7 @@ package com.earth.ureverse.inspector.controller;
 
 import com.earth.ureverse.global.auth.CustomUserDetails;
 import com.earth.ureverse.global.common.response.CommonResponseEntity;
+import com.earth.ureverse.inspector.dto.response.InspectionCompletedProductDto;
 import com.earth.ureverse.inspector.dto.response.PendingInspectionProductDto;
 import com.earth.ureverse.inspector.service.InspectorService;
 import lombok.RequiredArgsConstructor;
@@ -29,11 +30,18 @@ public class InspectorController {
     public ResponseEntity<CommonResponseEntity<Object>> getPendingInspectionProducts(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        if (!"ROLE_INSPECTOR".equals(userDetails.getRole())) {
-            throw new AccessDeniedException("검수자 권한이 필요합니다.");
-        }
         List<PendingInspectionProductDto> result =
                 inspectorService.getPendingInspectionProductsByInspector(userDetails.getUserId());
+        return ResponseEntity.ok(CommonResponseEntity.success(result));
+    }
+
+    // 검수 완료된 상품 목록 조회
+    @GetMapping("/completed-products")
+    public ResponseEntity<CommonResponseEntity<Object>> getInspectionCompletedProducts(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        List<InspectionCompletedProductDto> result =
+                inspectorService.getInspectionCompletedProductsByInspector(userDetails.getUserId());
         return ResponseEntity.ok(CommonResponseEntity.success(result));
     }
 }

--- a/src/main/java/com/earth/ureverse/inspector/dto/response/InspectionCompletedProductDto.java
+++ b/src/main/java/com/earth/ureverse/inspector/dto/response/InspectionCompletedProductDto.java
@@ -1,0 +1,16 @@
+package com.earth.ureverse.inspector.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class InspectionCompletedProductDto {
+    private Long productId;
+    private String brandName;
+    private String categoryName;
+    private String status;
+    private String imageUrl; // 대표 이미지 1개
+    private String createdAt;
+    private Integer expectedPoint;
+}

--- a/src/main/java/com/earth/ureverse/inspector/service/InspectorService.java
+++ b/src/main/java/com/earth/ureverse/inspector/service/InspectorService.java
@@ -1,5 +1,6 @@
 package com.earth.ureverse.inspector.service;
 
+import com.earth.ureverse.inspector.dto.response.InspectionCompletedProductDto;
 import com.earth.ureverse.inspector.dto.response.PendingInspectionProductDto;
 
 import java.util.List;
@@ -7,4 +8,5 @@ import java.util.List;
 public interface InspectorService {
     List<PendingInspectionProductDto> getPendingInspectionProductsByInspector(Long inspectorId);
 
+    List<InspectionCompletedProductDto> getInspectionCompletedProductsByInspector(Long inspectorId);
 }

--- a/src/main/java/com/earth/ureverse/inspector/service/InspectorServiceImpl.java
+++ b/src/main/java/com/earth/ureverse/inspector/service/InspectorServiceImpl.java
@@ -1,6 +1,7 @@
 package com.earth.ureverse.inspector.service;
 
 import com.earth.ureverse.global.mapper.ProductMapper;
+import com.earth.ureverse.inspector.dto.response.InspectionCompletedProductDto;
 import com.earth.ureverse.inspector.dto.response.PendingInspectionProductDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -16,5 +17,10 @@ public class InspectorServiceImpl implements InspectorService{
     @Override
     public List<PendingInspectionProductDto> getPendingInspectionProductsByInspector(Long inspectorId) {
         return productMapper.getPendingInspectionProductsByInspector(inspectorId);
+    }
+
+    @Override
+    public List<InspectionCompletedProductDto> getInspectionCompletedProductsByInspector(Long inspectorId) {
+        return productMapper.getInspectionCompletedProductsByInspector(inspectorId);
     }
 }

--- a/src/main/resources/mappers/ProductMapper.xml
+++ b/src/main/resources/mappers/ProductMapper.xml
@@ -52,4 +52,35 @@
         WHERE p.status = 'FINISH'
     </select>
 
+    <select id="getInspectionCompletedProductsByInspector"
+            resultType="com.earth.ureverse.inspector.dto.response.InspectionCompletedProductDto">
+
+        SELECT
+        p.product_id AS productId,
+        b.name AS brandName,
+        c.name AS categoryName,
+        p.status AS status,
+        img.url AS imageUrl,
+        TO_CHAR(p.created_at, 'YYYY-MM-DD HH24:MI:SS') AS createdAt,
+        bcc.point AS expectedPoint
+        FROM product p
+        JOIN brand b ON p.brand_id = b.brand_id
+        JOIN category c ON p.category_id = c.category_id
+        JOIN brand_category_combination bcc
+        ON p.brand_id = bcc.brand_id
+        AND p.category_id = bcc.category_id
+        AND bcc.inspector_id = #{inspectorId}
+        LEFT JOIN (
+        SELECT product_id,
+        MIN(url) KEEP (DENSE_RANK FIRST ORDER BY created_at) AS url
+        FROM product_image
+        GROUP BY product_id
+        ) img ON img.product_id = p.product_id
+        WHERE p.status = 'REJECT'
+        OR p.status = 'SECOND_INSPECT'
+        OR p.status = 'DELIVERY_REQUEST'
+        OR p.status = 'DELIVERING'
+        OR p.status = 'FINISH'
+    </select>
+
 </mapper>


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스
- close #10
- [Notion-API](https://www.notion.so/20635212d33b811c9ff6c506c80d5ab8) 

<br/>

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?
    - 검수 완료된 상품 목록 조회 (REJECT, SECOND_INSPECT, DELIVERY_REQUEST, DELIVERING, FINISH)
    - 검수자 권한 체크 중복 로직 제거 (Spring Security)
<br/>

![image](https://github.com/user-attachments/assets/212f6459-f595-4ca5-8977-c86e73cf2b93)
<br/>

![image](https://github.com/user-attachments/assets/bdafc612-57e9-4c60-9565-ae81ae4f2a65)

<br/>

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점
    - 검수 완료 상태 합의
    - 날짜값을 상품 등록일로 정할건지 합의

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부
    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리
    - [추가] : No
