### PR TITLE
Feat: 날짜별 검수결과통계(PASS/FAIL)

### DIFF
--- a/src/main/java/com/earth/ureverse/admin/controller/AdminController.java
+++ b/src/main/java/com/earth/ureverse/admin/controller/AdminController.java
@@ -74,4 +74,12 @@ public class AdminController {
         return CommonResponseEntity.success("수거 요청이 등록되었습니다.");
     }
 
+    @GetMapping("/dash-boards/inspection-result/{date}/{method}")
+    public CommonResponseEntity<DashBoardInspectionResultRatioResponse> getInspectionResultRatio(
+            @PathVariable String date,
+            @PathVariable String method
+    ){
+        return CommonResponseEntity.success(adminProductService.getInspectionResultRatio(date, method));
+    }
+
 }

--- a/src/main/java/com/earth/ureverse/admin/dto/response/DashBoardInspectionResultRatioResponse.java
+++ b/src/main/java/com/earth/ureverse/admin/dto/response/DashBoardInspectionResultRatioResponse.java
@@ -1,0 +1,29 @@
+package com.earth.ureverse.admin.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DashBoardInspectionResultRatioResponse {
+    private Integer totalCount;
+    private Integer passCount; //통과 건수
+    private Integer failCount; //탈락 건수
+
+    public double getPassRatio(){
+        double result = totalCount != null && totalCount>0
+                        ? Math.round((double) passCount / totalCount * 10000) / 100.0
+                        : 0.0;
+        return result;
+    }
+    public double getFailRatio(){
+        double result = totalCount != null && totalCount>0
+                ? Math.round((double) failCount / totalCount * 10000) / 100.0
+                : 0.0;
+        return result;
+    }
+}

--- a/src/main/java/com/earth/ureverse/admin/service/AdminProductService.java
+++ b/src/main/java/com/earth/ureverse/admin/service/AdminProductService.java
@@ -23,4 +23,6 @@ public interface AdminProductService {
     DashBoardSummaryResponse getDashBoardSummary(String date);
 
     void requestPickup(CustomUserDetails customUserDetails, Long productId);
+
+    DashBoardInspectionResultRatioResponse getInspectionResultRatio(String date, String method);
 }

--- a/src/main/java/com/earth/ureverse/admin/service/AdminProductServiceImpl.java
+++ b/src/main/java/com/earth/ureverse/admin/service/AdminProductServiceImpl.java
@@ -81,6 +81,7 @@ public class AdminProductServiceImpl implements AdminProductService {
         productStatusAsyncService.updateStatusWithDelay(productId, adminId);
     }
 
+
     @Override
     public DashBoardSummaryResponse getDashBoardSummary(String date) {
         if(!isValidDateTimeFormat(date)){
@@ -111,5 +112,16 @@ public class AdminProductServiceImpl implements AdminProductService {
         LocalDate startOfWeek = date.minusDays(dayOfWeek.getValue());
         LocalDate endOfWeek = startOfWeek.plusDays(6);
         return new LocalDate[]{startOfWeek, endOfWeek}; //월~일
+    }
+
+    @Override
+    public DashBoardInspectionResultRatioResponse getInspectionResultRatio(String date, String method) {
+        if(!isValidDateTimeFormat(date)){
+            throw new IllegalArgumentException("date형식이 아닙니다.");
+        }
+        if (!("AI".equalsIgnoreCase(method) || "Human".equalsIgnoreCase(method))) {
+            throw new IllegalArgumentException("검수 방식은 AI 또는 Human이어야 합니다.");
+        }
+        return productMapper.getInspectionResultRatio(date, method);
     }
 }

--- a/src/main/java/com/earth/ureverse/global/mapper/ProductMapper.java
+++ b/src/main/java/com/earth/ureverse/global/mapper/ProductMapper.java
@@ -77,4 +77,6 @@ public interface ProductMapper {
     Long getTotalPaidPoint(String date);
 
     List<DashBoardBrandResponse> getTopBrandsOfWeek(String startDate, String endDate);
+
+    DashBoardInspectionResultRatioResponse getInspectionResultRatio(String date, String method);
 }

--- a/src/main/resources/mappers/ProductMapper.xml
+++ b/src/main/resources/mappers/ProductMapper.xml
@@ -557,4 +557,16 @@
         FETCH FIRST 3 ROWS ONLY
     </select>
 
+    <!--검수 결과 통계 (Pass/Fail)-->
+    <select id="getInspectionResultRatio" resultType="com.earth.ureverse.admin.dto.response.DashBoardInspectionResultRatioResponse">
+        SELECT
+            COUNT(*) AS totalCount,
+            SUM(CASE WHEN i.result = 'PASS' THEN 1 ELSE 0 END) AS passCount,
+            SUM(CASE WHEN i.result = 'FAIL' THEN 1 ELSE 0 END) AS failCount
+        FROM inspection i
+        WHERE TRUNC(i.created_at) = TO_DATE(#{date}, 'YYYY-MM-DD')
+            AND LOWER(i.inspect_method) = LOWER(#{method})
+    </select>
+
+
 </mapper>


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스
    - [Notion-API] : https://www.notion.so/21135212d33b80bb976ce1d5c8716eb2
    - [ISSUE] : https://github.com/UReverse-EarthGuard/UReverse-BE/issues/45

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?
    - 날짜별 검수(AI/검수자) 선택 후 해당 PASS/FAIL 결과 비율
![image](https://github.com/user-attachments/assets/40502102-dffa-4f71-ba51-f95307282616)
![image](https://github.com/user-attachments/assets/2deb08de-69ce-4887-8acd-627d590a11ed)

예외 : date형식이 아닐 때 / method가 ai/human이 아닐 때(대소문자 상관없음)
> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점
    - 

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부
    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리
    - [추가] : No
