### PR TITLE
[Fix] 포인트 총합 조회 쿼리 수정

### DIFF
--- a/src/main/resources/mappers/member/PointMapper.xml
+++ b/src/main/resources/mappers/member/PointMapper.xml
@@ -32,7 +32,7 @@
     </select>
 
     <select id="getTotalPoint" resultType="int">
-        SELECT SUM(PAID_POINT)
+        SELECT COALESCE(SUM(PAID_POINT), 0)
         FROM PRODUCT
         WHERE USER_ID = #{userId} AND STATUS = 'FINISH'
     </select>


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스
    - [Notion-API] : 

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?
    - 포인트 총합 조회 쿼리(getTotalPoint)에서 유저의 포인트가 없을 경우 NULL 반환으로 인해 500 에러가 발생하던 문제 수정
    - COALESCE(SUM(PAID_POINT), 0)로 변경하여 포인트가 없을 경우 0으로 안전하게 반환되도록 처리

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점
    - 

> ## 💾&nbsp;&nbsp;RDB 변경사항 여부
    - [업데이트] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리
    - [추가] : No
